### PR TITLE
Fix: (#45) implement responsiveness for overview pages

### DIFF
--- a/src/components/overview/Attendance.tsx
+++ b/src/components/overview/Attendance.tsx
@@ -65,8 +65,8 @@ const Attendance = () => {
   }
 
   return (
-    <div className="h-auto w-[90%] mx-auto pb-10">
-      <div className="bg-[#FFFFFF] rounded-lg flex flex-wrap items-center md:p-16 md:divide-x md:divide-gray-400">
+    <div className="h-auto w-[90%] max-w-[992px] mx-auto pb-10">
+      <div className="bg-[#FFFFFF] rounded-lg flex flex-wrap items-center md:py-4 md:divide-x md:divide-gray-400">
         {[
           { label: "Total scans", value: 39 },
           { label: "Confirmed scans", value: 31 },

--- a/src/components/overview/Attendance.tsx
+++ b/src/components/overview/Attendance.tsx
@@ -3,28 +3,28 @@ import React, { useState } from 'react'
 import scan from '@/assets/scan.svg'
 import Image from 'next/image'
 import check from '@/assets/check.svg'
-import {attendanceData} from '@/constants/data'
+import { attendanceData } from '@/constants/data'
 import AttendanceList from './AttendanceList'
 
 
 const Attendance = () => {
-    const [searchValue, setSearchValue] = useState("")
-    const [currentPage, setCurrentPage] = useState(1);
-    const itemsPerPage = 4;
-     // Calculate total pages
- const totalPages = Math.ceil(attendanceData.length / itemsPerPage);
+  const [searchValue, setSearchValue] = useState("")
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 4;
+  // Calculate total pages
+  const totalPages = Math.ceil(attendanceData.length / itemsPerPage);
 
- // Get current page items
- const currentItems = attendanceData.slice(
-   (currentPage - 1) * itemsPerPage,
-   currentPage * itemsPerPage
- );
+  // Get current page items
+  const currentItems = attendanceData.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage
+  );
 
- const goToPage = (page: any) => {
-  setCurrentPage(page);
-};
+  const goToPage = (page: any) => {
+    setCurrentPage(page);
+  };
 
-   const generatePageNumbers = () => {
+  const generatePageNumbers = () => {
     const pageNumbers = [];
     const maxVisiblePages = 10;
 
@@ -48,67 +48,60 @@ const Attendance = () => {
     return pageNumbers;
   };
 
- // Handle pagination controls
- const goToNextPage = () => {
-   setCurrentPage((prevPage) => Math.min(prevPage + 1, totalPages));
- };
+  // Handle pagination controls
+  const goToNextPage = () => {
+    setCurrentPage((prevPage) => Math.min(prevPage + 1, totalPages));
+  };
 
- const goToPreviousPage = () => {
-   setCurrentPage((prevPage) => Math.max(prevPage - 1, 1));
- };
-
-
+  const goToPreviousPage = () => {
+    setCurrentPage((prevPage) => Math.max(prevPage - 1, 1));
+  };
 
 
-    const handleChange = (event: { target: { value: any } }) => {
-        setSearchValue(event.target.value)
-       }
-       
+
+
+  const handleChange = (event: { target: { value: any } }) => {
+    setSearchValue(event.target.value)
+  }
+
   return (
-    <div className="h-auto w-full pb-10">
-            <div className="h-[150px] w-[80%] mx-auto bg-[#FFFFFF] rounded-lg flex justify-center space-x-24 items-center  px-16">
-                <div className="">
-                <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
-                Total scans
-                </p>
-                <h1 className="text-[#9B51E0] text-[29.7px] font-bold leading-[68.91px] opacity-40">
-                    39
-                </h1>
-                </div>
-                <div className="w-[1px] h-[80%] bg-[#9696966E]"></div>
-                <div>
-                <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
-                Confirmed scans
-                </p>
-                <h1 className="text-[#9B51E0] text-[29.7px] font-bold leading-[68.91px] opacity-40">
-                    31
-                </h1>
-                </div>
-                <div className="w-[1px]  h-[80%] bg-[#9696966E]"></div>
-                <div>
-                <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
-                Error scans
-                </p>
-                <h1 className="text-[#9B51E0] text-[29.7px] font-bold leading-[68.91px] opacity-40">
-                    3
-                </h1>
-                </div>
-            </div>
+    <div className="h-auto w-[90%] mx-auto pb-10">
+      <div className="bg-[#FFFFFF] rounded-lg flex flex-wrap items-center md:p-16 md:divide-x md:divide-gray-400">
+        {[
+          { label: "Total scans", value: 39 },
+          { label: "Confirmed scans", value: 31 },
+          { label: "Error scans", value: 3 }
+        ].map((item, index) => (
+          <div key={index} className="w-1/2 md:flex-1 text-center p-6">
+            <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
+              {item.label}
+            </p>
+            <h1 className="text-[#9B51E0] text-[29.7px] font-bold leading-[68.91px] opacity-40">
+              {item.value}
+            </h1>
+          </div>
+        ))}
+      </div>
 
-        <div className="h-[930px] w-[80%] mx-auto bg-[#FFFFFF] mt-4 rounded-lg">
-        <div className="flex justify-between px-16 pt-10">
-          <h1 className="text-[18px] font-medium leading-[22px] text-[#333333] mt-2">
-          Attendance
-          </h1>
-          <div className="flex space-x-8">
-            <div className="relative w-[550px] lclg:w-[380px]">
+      <div className="mx-auto p-4 lg:p-16 bg-[#FFFFFF] mt-4 rounded-lg">
+        <div className="relative">
+          <div className="flex justify-between items-center h-12">
+            <h1 className="text-[18px] lg:w-1/12 font-medium leading-[22px] text-[#333333]">
+              Attendance
+            </h1>
+            <Button className="lg:flex rounded-lg justify-center bg-[#2D3A4B] py-2 px-4 lg:h-[42px] items-center lg:w-[140px] text-sm text-[#FFFFFF] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
+              <div className="text-[11px] items-center font-semibold">Confirm Attendee</div>
+            </Button>
+          </div>
+          <div className="lg:absolute lg:left-[calc(100%/12*4)] lg:w-6/12 top-1 lg:w-[calc(100% - (100%/12 * 2) - 10px)]">
+            <div className="relative">
               <Input
                 name="search by address"
                 type="text"
-                placeholder="        Search wallet address"
+                placeholder="Search wallet address"
                 value={searchValue}
                 onChange={handleChange}
-                className="w-[90%] clg:w-[70%] lclg:w-[90%] p-2 border border-gray-300 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm text-gray-700 placeholder-gray-400"
+                className="w-full h-10 p-2 pl-8 border border-gray-300 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm text-gray-700 placeholder-gray-400"
               />
               {!searchValue && (
                 <svg
@@ -127,69 +120,66 @@ const Attendance = () => {
                 </svg>
               )}
             </div>
-            <Button className=" hidden lg:flex rounded-lg justify-center bg-[#2D3A4B] py-2 px-4 lg:h-[42px] items-center lg:w-[140px] text-sm text-[#FFFFFF] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
-              <div className="text-[11px] items-center font-semibold">Confirm Attendee</div>
-            </Button>
           </div>
-          </div>
+        </div>
 
-          <div className='h-[300px] w-full mt-6 flex items-center justify-center'>
-                <div className='w-[235px] h-[224px] border-[3px] border-[#4A90E2] rounded-xl mx-auto flex justify-center items-center'>
-                <Image src={scan} alt="scan" />
-                </div>
+        <div className='h-[300px] w-full mt-6 flex items-center justify-center'>
+          <div className='w-[235px] h-[224px] border-[3px] border-[#4A90E2] rounded-xl mx-auto flex justify-center items-center'>
+            <Image src={scan} alt="scan" />
+          </div>
         </div>
         <h1 className='mt-6 text-[18px] font-medium text-[#333333] leading-[22px] w-[92%] mx-auto'>Scan Results</h1>
-        <div className="w-[92%] mx-auto mt-2 h-[350px]">
-            <table className="w-full border-separate border-spacing-y-3">
-                <thead>
-                <tr className="h-[56px] w-full text-[14px] bg-[#9B51E052] text-[#5801A9] leading-[19.79px]">
-                    <th className="w-[50px] px-4 rounded-tl-xl rounded-bl-xl"><Image src={check} alt="ticket"  /></th>
-                    <th className=" text-center font-light">Name</th>
-                    <th className=" text-center font-light ">Address</th>
-                    <th className=" text-center font-light">Scan Status</th>
-                    <th className=" text-center font-light">Role</th>
-                    <th className="text-center font-light rounded-tr-xl rounded-br-xl">Reg date</th>
-                </tr>
-                </thead>
-                {currentItems.map((data, index)=>{
-            return <AttendanceList key={index} name={data.name} address={data.address} role={data.role} regdate={data.date} checkstat={data.checkstat} />
-        })}
-            </table>
+        <div className="mt-6 h-[350px] overflow-auto">
+          <table className="w-full border-separate border-spacing-y-3">
+            <thead>
+              <tr className="h-[56px] w-full text-[14px] bg-[#9B51E052] text-[#5801A9] leading-[19.79px]">
+                <th className="w-[50px] px-4 rounded-tl-xl rounded-bl-xl"><Image src={check} alt="ticket" /></th>
+                <th className=" text-center font-light">Name</th>
+                <th className=" text-center font-light ">Address</th>
+                <th className=" text-center font-light">Scan Status</th>
+                <th className=" text-center font-light">Role</th>
+                <th className="text-center font-light rounded-tr-xl rounded-br-xl">Reg date</th>
+              </tr>
+            </thead>
+            {currentItems.map((data, index) => {
+              return <AttendanceList key={index} name={data.name} address={data.address} role={data.role} regdate={data.date} checkstat={data.checkstat} />
+            })}
+          </table>
 
-            </div>
-            {/* Pagination Controls */}
-<div className="flex justify-center space-x-2 mt-4">
-        <button
-          onClick={goToPreviousPage}
-          disabled={currentPage === 1}
-          className="px-4 py-2 border-[#D0D5DD] border-[1px] rounded disabled:opacity-50"
-        >
-          {"<"}
-        </button>
-        {generatePageNumbers().map((page, index) =>
-          page == "..." ? (
-            <span key={index} className="px-2 text-base mt-2">...</span>
-          ) : (
-            <button
-              key={index}
-              onClick={() => goToPage(page)}
-              className={`px-4 py-2 rounded text-[14px] ${currentPage == page ? "bg-none text-[#000000] border-[#F56630] border-[1px]" : "bg-none text-[#000000]"}`}
-            >
-              {page}
-            </button>
-          )
-        )}
-        
-        <button
-          onClick={goToNextPage}
-          disabled={currentPage === totalPages}
-          className="px-4 py-2 border-[#D0D5DD] border-[1px] text-[20px] rounded disabled:opacity-50"
-        >
-          {">"}
-        </button>
+        </div>
+        {/* Pagination Controls */}
+        <div className="flex justify-center space-x-2 mt-4">
+          <button
+            onClick={goToPreviousPage}
+            disabled={currentPage === 1}
+            className="px-4 py-2 border-[#D0D5DD] border-[1px] rounded disabled:opacity-50"
+          >
+            {"<"}
+          </button>
+          {generatePageNumbers().map((page, index) =>
+            page == "..." ? (
+              <span key={index} className="px-2 text-base mt-2">...</span>
+            ) : (
+              <button
+                key={index}
+                onClick={() => goToPage(page)}
+                className={`px-4 py-2 rounded text-[14px] ${currentPage == page ? "bg-none text-[#000000] border-[#F56630] border-[1px]" : "bg-none text-[#000000]"}`}
+              >
+                {page}
+              </button>
+            )
+          )}
+
+          <button
+            onClick={goToNextPage}
+            disabled={currentPage === totalPages}
+            className="px-4 py-2 border-[#D0D5DD] border-[1px] text-[20px] rounded disabled:opacity-50"
+          >
+            {">"}
+          </button>
+        </div>
+
       </div>
-
-        </div>        
     </div>
   )
 }

--- a/src/components/overview/Guestlist.tsx
+++ b/src/components/overview/Guestlist.tsx
@@ -113,15 +113,15 @@ const Guestlist = () => {
               Guest list
             </h1>
             {/* Group 3: Buttons */}
-            <div className="flex justify-between gap-4 lg:pl-4 lg:w-3/12">
-              <Button className="rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] flex space-x-4 items-center text-sm text-[#2D3A4B] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
+            <div className="flex justify-between gap-1 md:gap-4 lg:pl-4 lg:w-3/12">
+              <Button className="rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] flex space-x-1 md:space-x-4 items-center text-sm text-[#2D3A4B] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
                 <div className="flex space-x-4 items-center font-semibold text-[16px]">
                   <Image src={downlaod} alt="ticket" className="mr-2" />
                 </div>
                 <div className="text-[11px]">Download</div>
               </Button>
 
-              <Button className="rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] flex space-x-4 items-center text-sm text-[#2D3A4B] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
+              <Button className="rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] flex space-x-1 md:space-x-4 items-center text-sm text-[#2D3A4B] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
                 <div className="font-semibold text-[16px]">
                   <Image src={filter} alt="ticket" className="mr-2" />
                 </div>

--- a/src/components/overview/Guestlist.tsx
+++ b/src/components/overview/Guestlist.tsx
@@ -66,9 +66,9 @@ const Guestlist = () => {
   }
 
   return (
-    <div className="h-auto w-full pb-10">
-      <div className="h-[150px] w-[80%] mx-auto bg-[#FFFFFF] rounded-lg flex justify-between items-center  px-16">
-        <div className="">
+    <div className="h-auto w-full pb-10 px-4 lg:px-0">
+      <div className="h-auto md:w-[80%] mx-auto bg-[#FFFFFF] rounded-lg flex flex-wrap justify-between items-center px-4 md:px-16 py-8 md:py-0 md:h-[150px]">
+        <div className="w-[45%] md:w-auto mb-8 md:mb-0">
           <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
             Your Guests
           </p>
@@ -76,8 +76,8 @@ const Guestlist = () => {
             39
           </h1>
         </div>
-        <div className="w-[1px] h-[80%] bg-[#9696966E]"></div>
-        <div>
+        <div className="hidden md:block w-[1px] h-[80%] bg-[#9696966E]"></div>
+        <div className="w-[45%] md:w-auto mb-8 md:mb-0">
           <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
             Approved attendance
           </p>
@@ -85,8 +85,8 @@ const Guestlist = () => {
             31
           </h1>
         </div>
-        <div className="w-[1px]  h-[80%] bg-[#9696966E]"></div>
-        <div>
+        <div className="hidden md:block w-[1px] h-[80%] bg-[#9696966E]"></div>
+        <div className="w-[45%] md:w-auto">
           <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
             Disapproved attendance
           </p>
@@ -94,8 +94,8 @@ const Guestlist = () => {
             3
           </h1>
         </div>
-        <div className="w-[1px]  h-[80%] bg-[#9696966E]"></div>
-        <div>
+        <div className="hidden md:block w-[1px] h-[80%] bg-[#9696966E]"></div>
+        <div className="w-[45%] md:w-auto">
           <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
             Pending Attendance
           </p>
@@ -105,20 +105,41 @@ const Guestlist = () => {
         </div>
       </div>
 
-      <div className="h-[930px] w-[80%] mx-auto bg-[#FFFFFF] mt-4 rounded-lg">
-        <div className="flex justify-between px-16 pt-10">
-          <h1 className="text-[18px] font-medium leading-[22px]  text-[#333333] mt-2">
-            Guest list
-          </h1>
-          <div className="flex space-x-8">
-            <div className="relative w-[550px] lclg:w-[380px]">
+      <div className="p-4 lg:p-16 mx-auto bg-[#FFFFFF] mt-4 rounded-lg">
+        <div className="relative">
+          {/* Group 1: Header */}
+          <div className="flex justify-between items-center h-12 mb-4">
+            <h1 className="text-[18px] lg:w-1/12 font-medium leading-[22px] text-[#333333]">
+              Guest list
+            </h1>
+            {/* Group 3: Buttons */}
+            <div className="flex justify-between gap-4 lg:pl-4 lg:w-3/12">
+              <Button className="rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] flex space-x-4 items-center text-sm text-[#2D3A4B] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
+                <div className="flex space-x-4 items-center font-semibold text-[16px]">
+                  <Image src={downlaod} alt="ticket" className="mr-2" />
+                </div>
+                <div className="text-[11px]">Download</div>
+              </Button>
+
+              <Button className="rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] flex space-x-4 items-center text-sm text-[#2D3A4B] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
+                <div className="font-semibold text-[16px]">
+                  <Image src={filter} alt="ticket" className="mr-2" />
+                </div>
+                <div className="text-[11px]">Filter</div>
+              </Button>
+            </div>
+          </div>
+
+          {/* Group 2: Search Input - Goes to the bottom on mobile */}
+          <div className="lg:absolute lg:left-[calc(100%/12*3)] lg:w-6/12 top-1 lg:w-[calc(100% - (100%/12 * 2) - 10px)]">
+            <div className="relative">
               <Input
                 name="search by address"
                 type="text"
-                placeholder="        Search guest, wallet address, role..."
+                placeholder="Search guest, wallet address, role..."
                 value={searchValue}
                 onChange={handleChange}
-                className="w-[90%] clg:w-[70%] lclg:w-[90%] p-2 border border-gray-300 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm text-gray-700 placeholder-gray-400"
+                className="w-full h-10 p-2 pl-8 border border-gray-300 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm text-gray-700 placeholder-gray-400"
               />
               {!searchValue && (
                 <svg
@@ -137,22 +158,10 @@ const Guestlist = () => {
                 </svg>
               )}
             </div>
-            <Button className=" hidden lg:flex rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] items-center lg:w-[125px] text-sm text-[#5801A9] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
-              <div className="flex space-x-4 items-center font-semibold text-[16px]">
-                <Image src={downlaod} alt="ticket" className="mr-2" />
-              </div>
-              <div className="text-[11px]">Download</div>
-            </Button>
-
-            <Button className="hidden lg:flex rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[42px] items-center lg:w-[90px] text-sm text-[#5801A9] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
-              <div className="flex space-x-4 items-center font-semibold text-[16px]">
-                <Image src={filter} alt="ticket" className="mr-2" />
-              </div>
-              <div className="text-[11px]">Filter</div>
-            </Button>
           </div>
+
         </div>
-        <div className="w-[92%] mx-auto mt-6 h-[750px]">
+        <div className="mt-6 h-[750px] overflow-y-auto">
           <table className="w-full border-separate border-spacing-y-3 ">
             <thead>
               <tr className="h-[56px] text-[14px] bg-[#9B51E052] font-normal text-[#5801A9] leading-[19.79px]">
@@ -189,9 +198,9 @@ const Guestlist = () => {
           <button
             onClick={goToPreviousPage}
             disabled={currentPage === 1}
-            className="px-4 py-2 border-[#D0D5DD] border-[1px] rounded disabled:opacity-50"
+            className="px-4 py-2 border-[#D0D5DD] border-[1px] text-[20px] rounded disabled:opacity-50"
           >
-            {"<"}
+            &lsaquo;
           </button>
           {generatePageNumbers().map((page, index) =>
             page == "..." ? (
@@ -202,7 +211,7 @@ const Guestlist = () => {
               <button
                 key={index}
                 onClick={() => goToPage(page)}
-                className={`px-4 py-2 rounded text-[14px] ${currentPage == page ? "bg-none text-[#000000] border-[#F56630] border-[1px]" : "bg-none text-[#000000]"}`}
+                className={`px-4 py-2 rounded text-[14px] ${currentPage == page ? "bg-none text-[#000000] border-[#9B51E0] border-[1px]" : "bg-none text-[#000000]"}`}
               >
                 {page}
               </button>
@@ -214,7 +223,7 @@ const Guestlist = () => {
             disabled={currentPage === totalPages}
             className="px-4 py-2 border-[#D0D5DD] border-[1px] text-[20px] rounded disabled:opacity-50"
           >
-            {">"}
+            &rsaquo;
           </button>
         </div>
       </div>

--- a/src/components/overview/Guestlist.tsx
+++ b/src/components/overview/Guestlist.tsx
@@ -66,8 +66,8 @@ const Guestlist = () => {
   }
 
   return (
-    <div className="h-auto w-full pb-10 px-4 lg:px-0">
-      <div className="h-auto md:w-[80%] mx-auto bg-[#FFFFFF] rounded-lg flex flex-wrap justify-between items-center px-4 md:px-16 py-8 md:py-0 md:h-[150px]">
+    <div className="h-auto w-full md:w-[90%] max-w-[992px] mx-auto pb-10 px-4 lg:px-0">
+      <div className="h-auto bg-[#FFFFFF] rounded-lg flex flex-wrap justify-between items-center px-4 md:px-16 py-8 md:py-0 md:h-[150px]">
         <div className="w-[45%] md:w-auto mb-8 md:mb-0">
           <p className="text-[#2D3A4B] text-[16px] font-medium leading-[18px]">
             Your Guests

--- a/src/components/overview/Insight.tsx
+++ b/src/components/overview/Insight.tsx
@@ -5,151 +5,117 @@ import { Button } from '@headlessui/react'
 import drop from '@/assets/drop.svg'
 import Emailinput from './Emailinput'
 import cross from '@/assets/cross.svg'
-import share from '@/assets/share.svg'
+import share from '@/assets/share.svg';
 import del from '@/assets/delete.svg'
 import ChartData from './ChartData'
+
 
 const Insight = () => {
     const [emailList, setEmailList] = useState<string[]>([]);
 
     const handleEmailsChange = (emails: string[]) => {
-      setEmailList(emails);
+        setEmailList(emails);
     };
 
-  return (
-    <div className='h-auto pb-8 sm:pb-16 md:pb-32'>
-        <div className='w-full px-5 sm:px-0 sm:w-[95%] md:w-[992px] h-[100%] mx-auto'>
-            {/* Image container with responsive positioning */}
-            <div className='w-[196px] h-[184px] rounded-lg overflow-hidden relative  sm:left-[24px]
-                          mx-auto sm:mx-0 md:mx-0
-                          sm:mt-0 md:mt-0 mt-[380px]
-                          sm:ml-0 md:ml-0 ml-[24px]'>
-                <Image src={story} alt="story" objectFit="cover" layout='fill' />
-            </div>
 
-            {/* Event Name with responsive styles */}
-            <h1 className='mt-3 font-bold leading-[68.91px] opacity-[0.43]
-                          text-center sm:text-left md:text-left
-                          text-[29.7px] sm:text-[29.7px] md:text-[29.7px]
-                          text-[#A666E3] sm:text-[#ABADBA] md:text-[#ABADBA]'>
-                Event Name
-            </h1>
-
-            <div>
-                {/* Event Registration header and Past Week button */}
-                <div className='flex flex-col sm:flex-row md:flex-row justify-between items-center gap-4 sm:gap-0 md:gap-0'>
-                    <h1 className='font-medium text-[14px] sm:text-[16px] md:text-[16px] text-[#2D3A4B] 
-                                  leading-[11.01px] sm:leading-[18.15px] md:leading-[18.15px]
-                                  text-center sm:text-left md:text-left'>
-                        Event Registration
-                    </h1>
-                    {/* Past Week button with mobile-specific positioning */}
-                    <div className='w-full sm:w-auto md:w-auto order-1 sm:order-none md:order-none'>
-                        <Button className='w-full sm:w-[154.14px] md:w-[154.14px] bg-[#2D3A4B91] text-[#FFFFFF] 
-                                         font-light text-[14px] rounded-lg h-[39.39px] items-center flex justify-center
-                                         px-[27px] py-[8.25px] gap-[8.25px]'>
-                            <Image src={drop} alt='drop' className='mr-2'/>
+    return (
+        <div className='h-auto pb-32'>
+            <div className='w-[90%] h-[100%] mx-auto'>
+                <div className='w-[196px] h-[184px] rounded-lg overflow-hidden relative'>
+                    <Image src={story} alt="story" objectFit="cover" layout='fill' />
+                </div>
+                <h1 className='mt-4 text-[#ABADBA] text-[29.7px] font-bold leading-[68px]'>Event Name</h1>
+                <div>
+                    <div className='flex flex-col md:flex-row justify-between items-start gap-4 w-full'>
+                        <h1 className='font-medium text-[16px] text-[#2D3A4B] leading-[18.15px]'>Event Registration</h1>
+                        <div className='w-full md:w-[582px] bg-[#FFFFFF] h-[272px] rounded-lg'>
+                            <ChartData />
+                        </div>
+                    </div>
+                    <div className='mt-8 flex flex-col md:flex-row gap-4 md:gap-0 justify-between items-end w-full'>
+                        <Button className='bg-[#2D3A4B91] text-[#FFFFFF] font-light text-[14px] rounded-lg h-[39px] w-[155px] items-center flex justify-center'>
+                            <Image src={drop} alt='drop' className='mr-2' />
                             Past Week
                         </Button>
-                    </div>
-                </div>
 
-                {/* Charts and Stats section */}
-                <div className='flex flex-col sm:flex-row md:flex-row justify-between mt-3 gap-4 sm:w-[364.52] sm:h-[297]'>
-                    {/* Chart container */}
-                    <div className='w-full max-w-[353px] sm:max-w-none md:max-w-none sm:w-[582px] md:w-[582px] 
-                                  h-[164.98px] sm:h-[272px] md:h-[272px] 
-                                  bg-[#FFFFFF] rounded-lg mx-auto sm:mx-0 md:mx-0'>
-                        <ChartData />
-                    </div>
-                    
-                    {/* Stats card */}
-                    <div className='w-full max-w-[364.52px] sm:max-w-none md:max-w-none sm:w-[396px] md:w-[396px] 
-                                  h-[297px] sm:h-[272px] md:h-[272px] 
-                                  bg-[#2D3A4B] rounded-lg shadow-sm mx-auto sm:mx-0 md:mx-0'>                 
-                        <div className='flex flex-col sm:flex-row md:flex-row justify-between px-6 sm:px-14 md:px-14 pt-6 sm:pt-10 md:pt-10 pb-6'>
-                            <div className='space-y-3 text-center sm:text-left md:text-left'>
-                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Total Registration</h1>
-                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>36</h1>
+                        <div className='w-full md:w-[396px] h-[272px] bg-[#2D3A4B] rounded-lg shadow-sm'>
+                            <div className='flex justify-between px-14 pt-10 pb-6'>
+                                <div className='space-y-3'>
+                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Total Registration</h1>
+                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>36</h1>
+                                </div>
+                                <div className='space-y-3'>
+                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Highest Daily Reg</h1>
+                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>Saturday</h1>
+                                </div>
                             </div>
-                            <div className='space-y-3 text-center sm:text-left md:text-left mt-4 sm:mt-0 md:mt-0'>
-                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Highest Daily Reg</h1>
-                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>Saturday</h1>
+
+                            <div className='flex justify-between px-14 pb-6'>
+                                <div className='space-y-3'>
+                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Event Managers/hosts</h1>
+                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>5</h1>
+                                </div>
+                                <div className='space-y-3'>
+                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Approvals Granted</h1>
+                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>31</h1>
+                                </div>
+                            </div>
+                            <div className='flex justify-between px-14 pb-4'>
+                                <div className='space-y-3'>
+                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Disapprovals</h1>
+                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>3</h1>
+                                </div>
+                                <div className='space-y-3'></div>
+                            </div>
+
+
+                        </div>
+                    </div>
+                    <div className='w-full flex flex-col md:flex-row gap-8 md:gap-0 p-8 md:w-[992px] bg-[#FFFFFF] rounded-lg mt-4 shadow-sm'>
+                        <div>
+                            <h1 className='text-[#2D3A4B] text-[16px] font-medium leading-[18.15px]'>Event Registeration URL</h1>
+                            <div className='mt-5'>
+                                <div className='flex flex-col md:flex-row items-end md:items-center gap-4 relative'>
+                                    <div className='w-full md:flex-1 flex items-center border-2 border-gray-300 rounded-lg overflow-hidden'>
+                                        <span className='bg-gray-100 text-[#2D3A4B] font-medium px-4 py-2 border-r-2 text-sm border-gray-300'>https://attensys.io</span>
+                                        <input
+                                            type="text"
+                                            className='flex-1 px-4 py-2 focus:outline-none focus:ring-1 focus:ring-[#9B51E0] w-[80%]'
+                                            readOnly
+                                            value="/event-registration-link"
+                                        />
+                                    </div>
+                                    <Button className='md:w-[130px] px-6 py-4 flex items-center justify-center bg-[#53545C45] text-[#333333] font-semibold text-[12px] rounded-lg h-[36px] md:absolute md:right-4'>
+                                        Share Link
+                                        <Image src={share} alt='drop' className='ml-2' />
+                                    </Button>
+                                </div>
                             </div>
                         </div>
 
-                        <div className='flex flex-col sm:flex-row md:flex-row justify-between px-6 sm:px-14 md:px-14 pb-6'>
-                            <div className='space-y-3 text-center sm:text-left md:text-left'>
-                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Event Managers/hosts</h1>
-                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>5</h1>
-                            </div>
-                            <div className='space-y-3 text-center sm:text-left md:text-left mt-4 sm:mt-0 md:mt-0'>
-                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Approvals Granted</h1>
-                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>31</h1>
-                            </div>
-                        </div>
-
-                        <div className='flex flex-col sm:flex-row md:flex-row justify-between px-6 sm:px-14 md:px-14 pb-4'>
-                            <div className='space-y-3 text-center sm:text-left md:text-left'>
-                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Disapprovals</h1>
-                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>3</h1>
-                            </div>
-                            <div className='space-y-3'></div>
-                        </div>
-                    </div>
-                </div>
-
-                {/* URL and Managers section */}
-                <div className='w-full max-w-[396px] sm:max-w-none md:max-w-none sm:w-[992px] md:w-[992px] 
-                              h-[382px] sm:h-[362px] md:h-[362px] 
-                              bg-[#FFFFFF] rounded-lg mt-4 shadow-sm mx-auto sm:mx-0 md:mx-0'>
-                    <div className='w-[90%] sm:w-[80%] md:w-[80%] mx-auto pt-6 sm:pt-12 md:pt-12'>
-                        <h1 className='text-center sm:text-left md:text-left'>Event Registration URL</h1>
-                        <div className='w-full max-w-[357.06px] sm:max-w-[626px] md:max-w-[626px] h-[60px] 
-                                      border-[2px] rounded-2xl mt-5 mx-auto sm:mx-0 md:mx-0'>
-                            <div className='flex flex-col sm:flex-row md:flex-row items-center justify-between p-4 sm:px-5 md:px-5 gap-4'>
-                                <h1 className='sm:border-r-[2px] md:border-r-[2px] sm:h-[60px] md:h-[60px] 
-                                             flex items-center sm:pr-4 md:pr-4 text-center sm:text-left md:text-left'>
-                                    https://attensys.io
-                                </h1>
-                                <Button className='w-[142px] sm:w-[130px] md:w-[130px] bg-[#53545C45] text-[#333333] 
-                                               font-semibold text-[12px] rounded-lg h-[42.93px] sm:h-[36px] md:h-[36px] 
-                                               items-center flex justify-center'>
-                                    Share Link
-                                    <Image src={share} alt='share' className='ml-2'/>
-                                </Button>
+                        <div>
+                            <h1 className='text-[#2D3A4B] text-[16px] font-medium leading-[18.15px]'>Assigned Managers</h1>
+                            <div className='flex flex-col md:flex-row space-y-3 md:space-y-0 md:space-x-3 items-center'>
+                                <div className='w-full md:w-[590px] h-[60px] border-[2px] rounded-2xl mt-5'>
+                                    <Emailinput onEmailsChange={handleEmailsChange} />
+                                </div>
+                                <div className='w-full flex justify-end md:w-auto'>
+                                    <Button className='bg-[#4A90E21F] text-[#5801A9] font-normal text-[14px] rounded-lg h-[48px] w-[155px] items-center flex justify-center mt-5'>
+                                        <Image src={cross} alt='drop' className='mr-2' />
+                                        Assign manager</Button>
+                                </div>
                             </div>
                         </div>
                     </div>
-
-                    <div className='w-[90%] sm:w-[80%] md:w-[80%] mx-auto pt-6 sm:pt-12 md:pt-12'>
-                        <h1 className='text-center sm:text-left md:text-left'>Assigned Managers</h1>
-                        <div className='flex flex-col sm:flex-row md:flex-row gap-3 items-center'>
-                            <div className='w-full sm:w-[590px] md:w-[590px] h-[60px] border-[2px] rounded-2xl mt-5'>
-                                <Emailinput onEmailsChange={handleEmailsChange} />
-                            </div>
-                            <Button className='w-full sm:w-[155px] md:w-[155px] bg-[#4A90E21F] text-[#5801A9] 
-                                           font-normal text-[14px] rounded-lg h-[48px] items-center flex justify-center mt-5
-                                           border sm:border-none md:border-none border-[#5801A9]'>
-                                <Image src={cross} alt='cross' className='mr-2'/>
-                                Assign manager
-                            </Button>   
-                        </div>
+                    <div className='flex justify-center md:justify-end w-full'>
+                        <Button className='bg-[#E0515152] text-[#730404] font-normal text-[14px] rounded-lg h-[48px] w-[155px] items-center flex justify-center mt-5'>
+                            <Image src={del} alt='drop' className='mr-2' />
+                            Cancel Event</Button>
                     </div>
-                </div>
-
-                {/* Cancel Event button */}
-                <div className='flex justify-center sm:justify-end md:justify-end mt-5'>
-                    <Button className='w-[165px] bg-[#E0515152] text-[#730404] font-normal text-[14px] rounded-lg h-[48px] 
-                                     items-center flex justify-center px-5 py-2.5 gap-2.5'>
-                        <Image src={del} alt='delete' className='mr-2'/>
-                        Cancel Event
-                    </Button>
                 </div>
             </div>
         </div>
-    </div>
-  )
+    )
 }
 
 export default Insight

--- a/src/components/overview/Insight.tsx
+++ b/src/components/overview/Insight.tsx
@@ -10,6 +10,7 @@ import del from '@/assets/delete.svg'
 import ChartData from './ChartData'
 
 
+
 const Insight = () => {
     const [emailList, setEmailList] = useState<string[]>([]);
 
@@ -20,67 +21,73 @@ const Insight = () => {
 
     return (
         <div className='h-auto pb-32'>
-            <div className='w-[90%] h-[100%] mx-auto'>
+            <div className='w-[90%] max-w-[992px] h-[100%] mx-auto'>
                 <div className='w-[196px] h-[184px] rounded-lg overflow-hidden relative'>
                     <Image src={story} alt="story" objectFit="cover" layout='fill' />
                 </div>
                 <h1 className='mt-4 text-[#ABADBA] text-[29.7px] font-bold leading-[68px]'>Event Name</h1>
-                <div>
-                    <div className='flex flex-col md:flex-row justify-between items-start gap-4 w-full'>
-                        <h1 className='font-medium text-[16px] text-[#2D3A4B] leading-[18.15px]'>Event Registration</h1>
-                        <div className='w-full md:w-[582px] bg-[#FFFFFF] h-[272px] rounded-lg'>
-                            <ChartData />
+                <div className='mt-8'>
+                    <div className='flex flex-col md:flex-row gap-2'>
+                        <div className='lg:basis-7/12 md:basis-1/2 md:w-1/2 lg:w-auto'>
+                            <div className='h-full flex flex-col gap-4 justify-between items-start'>
+                                <h1 className='font-medium text-[16px] text-[#2D3A4B] leading-[18.15px]'>Event Registration</h1>
+                                <div className='w-full md:w-full bg-[#FFFFFF] h-[272px] rounded-lg'>
+                                    <ChartData />
+                                </div>
+                            </div>
+                        </div>
+                        <div className="lg:basis-5/12 md:basis-1/2 md:w-1/2">
+                            <div className='flex flex-col gap-4 justify-between items-end md:flex-1 md:basis-1/3'>
+                                <Button className='bg-[#2D3A4B91] text-[#FFFFFF] font-light text-[14px] rounded-lg h-[39px] w-[155px] items-center flex justify-center'>
+                                    <Image src={drop} alt='drop' className='mr-2' />
+                                    Past Week
+                                </Button>
+
+                                <div className='w-full md:w-full h-[272px] bg-[#2D3A4B] rounded-lg shadow-sm'>
+                                    <div className='flex justify-between px-14 pt-10 pb-6'>
+                                        <div className='space-y-3'>
+                                            <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Total Registration</h1>
+                                            <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>36</h1>
+                                        </div>
+                                        <div className='space-y-3'>
+                                            <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Highest Daily Reg</h1>
+                                            <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>Saturday</h1>
+                                        </div>
+                                    </div>
+
+                                    <div className='flex justify-between px-14 pb-6'>
+                                        <div className='space-y-3'>
+                                            <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Event Managers/hosts</h1>
+                                            <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>5</h1>
+                                        </div>
+                                        <div className='space-y-3'>
+                                            <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Approvals Granted</h1>
+                                            <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>31</h1>
+                                        </div>
+                                    </div>
+                                    <div className='flex justify-between px-14 pb-4'>
+                                        <div className='space-y-3'>
+                                            <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Disapprovals</h1>
+                                            <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>3</h1>
+                                        </div>
+                                        <div className='space-y-3'></div>
+                                    </div>
+
+
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    <div className='mt-8 flex flex-col md:flex-row gap-4 md:gap-0 justify-between items-end w-full'>
-                        <Button className='bg-[#2D3A4B91] text-[#FFFFFF] font-light text-[14px] rounded-lg h-[39px] w-[155px] items-center flex justify-center'>
-                            <Image src={drop} alt='drop' className='mr-2' />
-                            Past Week
-                        </Button>
-
-                        <div className='w-full md:w-[396px] h-[272px] bg-[#2D3A4B] rounded-lg shadow-sm'>
-                            <div className='flex justify-between px-14 pt-10 pb-6'>
-                                <div className='space-y-3'>
-                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Total Registration</h1>
-                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>36</h1>
-                                </div>
-                                <div className='space-y-3'>
-                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Highest Daily Reg</h1>
-                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>Saturday</h1>
-                                </div>
-                            </div>
-
-                            <div className='flex justify-between px-14 pb-6'>
-                                <div className='space-y-3'>
-                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Event Managers/hosts</h1>
-                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>5</h1>
-                                </div>
-                                <div className='space-y-3'>
-                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Approvals Granted</h1>
-                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>31</h1>
-                                </div>
-                            </div>
-                            <div className='flex justify-between px-14 pb-4'>
-                                <div className='space-y-3'>
-                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Disapprovals</h1>
-                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>3</h1>
-                                </div>
-                                <div className='space-y-3'></div>
-                            </div>
-
-
-                        </div>
-                    </div>
-                    <div className='w-full flex flex-col md:flex-row gap-8 md:gap-0 p-8 md:w-[992px] bg-[#FFFFFF] rounded-lg mt-4 shadow-sm'>
+                    <div className='w-full gap-8 md:gap-0 p-8 bg-[#FFFFFF] rounded-lg mt-4 shadow-sm'>
                         <div>
-                            <h1 className='text-[#2D3A4B] text-[16px] font-medium leading-[18.15px]'>Event Registeration URL</h1>
+                            <h1 className='text-[#2D3A4B] text-[16px] font-medium leading-[18.15px]'>Event Registration URL</h1>
                             <div className='mt-5'>
-                                <div className='flex flex-col md:flex-row items-end md:items-center gap-4 relative'>
-                                    <div className='w-full md:flex-1 flex items-center border-2 border-gray-300 rounded-lg overflow-hidden'>
-                                        <span className='bg-gray-100 text-[#2D3A4B] font-medium px-4 py-2 border-r-2 text-sm border-gray-300'>https://attensys.io</span>
+                                <div className='flex flex-col md:flex-row items-end md:items-center gap-4 relative h-[60px]'>
+                                    <div className='w-full flex-1 flex items-center border-2 rounded-2xl h-full'>
+                                        <span className='bg-transparent text-[#2D3A4B] font-medium px-1 md:px-5 items-center border-r-2 text-xs md:text-base border-gray-300 inline-flex h-full'>https://attensys.io</span>
                                         <input
                                             type="text"
-                                            className='flex-1 px-4 py-2 focus:outline-none focus:ring-1 focus:ring-[#9B51E0] w-[80%]'
+                                            className='flex-1 px-1 md:px-4 h-full text-sm md:text-base py-2 border-gray-300 focus:outline-none rounded-r-2xl focus:ring-2 focus:ring-[#9B51E0] w-[80%]'
                                             readOnly
                                             value="/event-registration-link"
                                         />
@@ -93,7 +100,7 @@ const Insight = () => {
                             </div>
                         </div>
 
-                        <div>
+                        <div className='mt-12'>
                             <h1 className='text-[#2D3A4B] text-[16px] font-medium leading-[18.15px]'>Assigned Managers</h1>
                             <div className='flex flex-col md:flex-row space-y-3 md:space-y-0 md:space-x-3 items-center'>
                                 <div className='w-full md:w-[590px] h-[60px] border-[2px] rounded-2xl mt-5'>

--- a/src/components/overview/Insight.tsx
+++ b/src/components/overview/Insight.tsx
@@ -88,8 +88,7 @@ const Insight = () => {
                                         <input
                                             type="text"
                                             className='flex-1 px-1 md:px-4 h-full text-sm md:text-base py-2 border-gray-300 focus:outline-none rounded-r-2xl focus:ring-2 focus:ring-[#9B51E0] w-[80%]'
-                                            readOnly
-                                            value="/event-registration-link"
+                                            placeholder="/event-registration-link"
                                         />
                                     </div>
                                     <Button className='md:w-[130px] px-6 py-4 flex items-center justify-center bg-[#53545C45] text-[#333333] font-semibold text-[12px] rounded-lg h-[36px] md:absolute md:right-4'>
@@ -103,7 +102,7 @@ const Insight = () => {
                         <div className='mt-12'>
                             <h1 className='text-[#2D3A4B] text-[16px] font-medium leading-[18.15px]'>Assigned Managers</h1>
                             <div className='flex flex-col md:flex-row space-y-3 md:space-y-0 md:space-x-3 items-center'>
-                                <div className='w-full md:w-[590px] h-[60px] border-[2px] rounded-2xl mt-5'>
+                                <div className='w-full md:w-[590px] h-[60px] border-[2px] overflow-x-auto whitespace-nowrap rounded-2xl mt-5'>
                                     <Emailinput onEmailsChange={handleEmailsChange} />
                                 </div>
                                 <div className='w-full flex justify-end md:w-auto'>

--- a/src/components/overview/Insight.tsx
+++ b/src/components/overview/Insight.tsx
@@ -5,11 +5,9 @@ import { Button } from '@headlessui/react'
 import drop from '@/assets/drop.svg'
 import Emailinput from './Emailinput'
 import cross from '@/assets/cross.svg'
-import share from '@/assets/share.svg';
+import share from '@/assets/share.svg'
 import del from '@/assets/delete.svg'
 import ChartData from './ChartData'
-
-
 
 const Insight = () => {
     const [emailList, setEmailList] = useState<string[]>([]);
@@ -18,88 +16,136 @@ const Insight = () => {
       setEmailList(emails);
     };
 
-
   return (
-    <div className='h-auto pb-32'>
-        <div className='w-[992px] h-[100%] mx-auto'>
-            <div className='w-[196px] h-[184px] rounded-lg overflow-hidden relative'>
-            <Image src={story} alt="story" objectFit="cover" layout='fill'  />
+    <div className='h-auto pb-8 sm:pb-16 md:pb-32'>
+        <div className='w-full px-5 sm:px-0 sm:w-[95%] md:w-[992px] h-[100%] mx-auto'>
+            {/* Image container with responsive positioning */}
+            <div className='w-[196px] h-[184px] rounded-lg overflow-hidden relative  sm:left-[24px]
+                          mx-auto sm:mx-0 md:mx-0
+                          sm:mt-0 md:mt-0 mt-[380px]
+                          sm:ml-0 md:ml-0 ml-[24px]'>
+                <Image src={story} alt="story" objectFit="cover" layout='fill' />
             </div>
-            <h1 className='mt-3 text-[#ABADBA] text-[29.7px] font-bold leading-[68px]'>Event Name</h1>
+
+            {/* Event Name with responsive styles */}
+            <h1 className='mt-3 font-bold leading-[68.91px] opacity-[0.43]
+                          text-center sm:text-left md:text-left
+                          text-[29.7px] sm:text-[29.7px] md:text-[29.7px]
+                          text-[#A666E3] sm:text-[#ABADBA] md:text-[#ABADBA]'>
+                Event Name
+            </h1>
+
             <div>
-                    <div className='flex justify-between items-center'>
-                        <h1 className='font-medium text-[16px] text-[#2D3A4B] leading-[18.15px]'>Event Registration</h1>
-                        <Button className='bg-[#2D3A4B91] text-[#FFFFFF] font-light text-[14px] rounded-lg h-[39px] w-[155px] items-center flex justify-center'>
+                {/* Event Registration header and Past Week button */}
+                <div className='flex flex-col sm:flex-row md:flex-row justify-between items-center gap-4 sm:gap-0 md:gap-0'>
+                    <h1 className='font-medium text-[14px] sm:text-[16px] md:text-[16px] text-[#2D3A4B] 
+                                  leading-[11.01px] sm:leading-[18.15px] md:leading-[18.15px]
+                                  text-center sm:text-left md:text-left'>
+                        Event Registration
+                    </h1>
+                    {/* Past Week button with mobile-specific positioning */}
+                    <div className='w-full sm:w-auto md:w-auto order-1 sm:order-none md:order-none'>
+                        <Button className='w-full sm:w-[154.14px] md:w-[154.14px] bg-[#2D3A4B91] text-[#FFFFFF] 
+                                         font-light text-[14px] rounded-lg h-[39.39px] items-center flex justify-center
+                                         px-[27px] py-[8.25px] gap-[8.25px]'>
                             <Image src={drop} alt='drop' className='mr-2'/>
-                            Past Week</Button>
+                            Past Week
+                        </Button>
                     </div>
-                    <div className='flex justify-between mt-3'>
-                        <div className='w-[582px] bg-[#FFFFFF] h-[272px] rounded-lg'>
-                            <ChartData />
-                        </div>
-                        <div className='w-[396px] h-[272px] bg-[#2D3A4B] rounded-lg shadow-sm'>                 
-                                    <div className='flex justify-between px-14 pt-10 pb-6'>
-                                                <div className='space-y-3'>
-                                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Total Registration</h1>
-                                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>36</h1>
-                                                </div>
-                                                <div className='space-y-3'>
-                                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Highest Daily Reg</h1>
-                                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>Saturday</h1>
-                                                </div>
-                                    </div>
+                </div>
 
-                                    <div className='flex justify-between px-14 pb-6'>
-                                                <div className='space-y-3'>
-                                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Event Managers/hosts</h1>
-                                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>5</h1>
-                                                </div>
-                                                <div className='space-y-3'>
-                                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Approvals Granted</h1>
-                                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>31</h1>
-                                                </div>
-                                    </div>
-                                    <div className='flex justify-between px-14 pb-4'>
-                                                <div className='space-y-3'>
-                                                    <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Disapprovals</h1>
-                                                    <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>3</h1>
-                                                </div>
-                                                <div className='space-y-3'></div>
-                                    </div>
-
-
-                        </div>
+                {/* Charts and Stats section */}
+                <div className='flex flex-col sm:flex-row md:flex-row justify-between mt-3 gap-4 sm:w-[364.52] sm:h-[297]'>
+                    {/* Chart container */}
+                    <div className='w-full max-w-[353px] sm:max-w-none md:max-w-none sm:w-[582px] md:w-[582px] 
+                                  h-[164.98px] sm:h-[272px] md:h-[272px] 
+                                  bg-[#FFFFFF] rounded-lg mx-auto sm:mx-0 md:mx-0'>
+                        <ChartData />
                     </div>
-                    <div className='w-[992px] bg-[#FFFFFF] h-[362px] rounded-lg mt-4 shadow-sm'>
-                        <div className='w-[80%] mx-auto pt-12'>
-                        <h1>Event Registeration URL</h1>
-                                <div className='w-[626px] h-[60px] border-[2px] rounded-2xl mt-5 flex items-center justify-between px-5'>
-                                    <h1 className='border-r-[2px] h-[60px] flex items-center pr-4'>https://attensys.io</h1>
-                                    <Button className='bg-[#53545C45] text-[#333333] font-semibold text-[12px] rounded-lg h-[36px] w-[130px] items-center flex justify-center'>
-                            Share Link
-                            <Image src={share} alt='drop' className='ml-2'/>
-                            </Button>
-                                </div>
+                    
+                    {/* Stats card */}
+                    <div className='w-full max-w-[364.52px] sm:max-w-none md:max-w-none sm:w-[396px] md:w-[396px] 
+                                  h-[297px] sm:h-[272px] md:h-[272px] 
+                                  bg-[#2D3A4B] rounded-lg shadow-sm mx-auto sm:mx-0 md:mx-0'>                 
+                        <div className='flex flex-col sm:flex-row md:flex-row justify-between px-6 sm:px-14 md:px-14 pt-6 sm:pt-10 md:pt-10 pb-6'>
+                            <div className='space-y-3 text-center sm:text-left md:text-left'>
+                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Total Registration</h1>
+                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>36</h1>
+                            </div>
+                            <div className='space-y-3 text-center sm:text-left md:text-left mt-4 sm:mt-0 md:mt-0'>
+                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Highest Daily Reg</h1>
+                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>Saturday</h1>
+                            </div>
                         </div>
 
-                        <div className='w-[80%] mx-auto pt-12'>
-                        <h1>Assigned Managers</h1>
-                        <div className='flex space-x-3 items-center'>
-                                <div className='w-[590px] h-[60px] border-[2px] rounded-2xl mt-5'>
-                                    <Emailinput onEmailsChange={handleEmailsChange} />
-                                </div>
-                                <Button className='bg-[#4A90E21F] text-[#5801A9] font-normal text-[14px] rounded-lg h-[48px] w-[155px] items-center flex justify-center mt-5'>
-                            <Image src={cross} alt='drop' className='mr-2'/>
-                            Assign manager</Button>   
+                        <div className='flex flex-col sm:flex-row md:flex-row justify-between px-6 sm:px-14 md:px-14 pb-6'>
+                            <div className='space-y-3 text-center sm:text-left md:text-left'>
+                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Event Managers/hosts</h1>
+                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>5</h1>
+                            </div>
+                            <div className='space-y-3 text-center sm:text-left md:text-left mt-4 sm:mt-0 md:mt-0'>
+                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Approvals Granted</h1>
+                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>31</h1>
+                            </div>
                         </div>
-        
+
+                        <div className='flex flex-col sm:flex-row md:flex-row justify-between px-6 sm:px-14 md:px-14 pb-4'>
+                            <div className='space-y-3 text-center sm:text-left md:text-left'>
+                                <h1 className='text-[#FFFFFF] text-[13.2px] font-light leading-[18.15px]'>Disapprovals</h1>
+                                <h1 className='text-[#FFFFFF] font-semibold text-[19.8px] leading-[18.15px]'>3</h1>
+                            </div>
+                            <div className='space-y-3'></div>
                         </div>
                     </div>
-                    <div className='flex justify-end'>
-                    <Button className='bg-[#E0515152] text-[#730404] font-normal text-[14px] rounded-lg h-[48px] w-[155px] items-center flex justify-center mt-5'>
-                            <Image src={del} alt='drop' className='mr-2'/>
-                            Cancel Event</Button>
+                </div>
+
+                {/* URL and Managers section */}
+                <div className='w-full max-w-[396px] sm:max-w-none md:max-w-none sm:w-[992px] md:w-[992px] 
+                              h-[382px] sm:h-[362px] md:h-[362px] 
+                              bg-[#FFFFFF] rounded-lg mt-4 shadow-sm mx-auto sm:mx-0 md:mx-0'>
+                    <div className='w-[90%] sm:w-[80%] md:w-[80%] mx-auto pt-6 sm:pt-12 md:pt-12'>
+                        <h1 className='text-center sm:text-left md:text-left'>Event Registration URL</h1>
+                        <div className='w-full max-w-[357.06px] sm:max-w-[626px] md:max-w-[626px] h-[60px] 
+                                      border-[2px] rounded-2xl mt-5 mx-auto sm:mx-0 md:mx-0'>
+                            <div className='flex flex-col sm:flex-row md:flex-row items-center justify-between p-4 sm:px-5 md:px-5 gap-4'>
+                                <h1 className='sm:border-r-[2px] md:border-r-[2px] sm:h-[60px] md:h-[60px] 
+                                             flex items-center sm:pr-4 md:pr-4 text-center sm:text-left md:text-left'>
+                                    https://attensys.io
+                                </h1>
+                                <Button className='w-[142px] sm:w-[130px] md:w-[130px] bg-[#53545C45] text-[#333333] 
+                                               font-semibold text-[12px] rounded-lg h-[42.93px] sm:h-[36px] md:h-[36px] 
+                                               items-center flex justify-center'>
+                                    Share Link
+                                    <Image src={share} alt='share' className='ml-2'/>
+                                </Button>
+                            </div>
+                        </div>
                     </div>
+
+                    <div className='w-[90%] sm:w-[80%] md:w-[80%] mx-auto pt-6 sm:pt-12 md:pt-12'>
+                        <h1 className='text-center sm:text-left md:text-left'>Assigned Managers</h1>
+                        <div className='flex flex-col sm:flex-row md:flex-row gap-3 items-center'>
+                            <div className='w-full sm:w-[590px] md:w-[590px] h-[60px] border-[2px] rounded-2xl mt-5'>
+                                <Emailinput onEmailsChange={handleEmailsChange} />
+                            </div>
+                            <Button className='w-full sm:w-[155px] md:w-[155px] bg-[#4A90E21F] text-[#5801A9] 
+                                           font-normal text-[14px] rounded-lg h-[48px] items-center flex justify-center mt-5
+                                           border sm:border-none md:border-none border-[#5801A9]'>
+                                <Image src={cross} alt='cross' className='mr-2'/>
+                                Assign manager
+                            </Button>   
+                        </div>
+                    </div>
+                </div>
+
+                {/* Cancel Event button */}
+                <div className='flex justify-center sm:justify-end md:justify-end mt-5'>
+                    <Button className='w-[165px] bg-[#E0515152] text-[#730404] font-normal text-[14px] rounded-lg h-[48px] 
+                                     items-center flex justify-center px-5 py-2.5 gap-2.5'>
+                        <Image src={del} alt='delete' className='mr-2'/>
+                        Cancel Event
+                    </Button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/components/overview/OverviewDiscover.tsx
+++ b/src/components/overview/OverviewDiscover.tsx
@@ -8,54 +8,56 @@ import { Button } from '@headlessui/react'
 import edit from '@/assets/edit.svg'
 import goto from '@/assets/goto.svg'
 
-const OverviewDiscover = (props : any) => {
-    const router = useRouter();
-  
-    const handlerouting = () => {
-      router.push('/Events/events')
-    }
-    const handleEventPage = () =>{
-      router.push(`/Eventpage/${props.eventsname}`)
-    }
+const OverviewDiscover = (props: any) => {
+  const router = useRouter();
 
-    const handleDiscover = () => {
-      router.push('/Discoverevent')
-  
-    }
+  const handlerouting = () => {
+    router.push('/Events/events')
+  }
+  const handleEventPage = () => {
+    router.push(`/Eventpage/${props.eventsname}`)
+  }
+
+  const handleDiscover = () => {
+    router.push('/Discoverevent')
+
+  }
 
   return (
-    <div className='h-[100px] clg:h-[80px] lg:[70px] lclg:[60px] flex justify-between w-[90%] mx-auto items-center'>
-        <div className='flex w-[600px] clg:w-[700px] lclg:w-[700px] space-x-8 items-center'>
-            <div onClick={handleDiscover} className='flex space-x-3 items-center cursor-pointer'>
+    <div className='h-[180px] clg:h-[80px] lg:h-[70px] lclg:h-[60px] flex flex-col lg:flex-row justify-around w-[90%] mx-auto items-start lg:items-stretch'>
+      <div className="overflow-x-auto whitespace-nowrap w-full">
+        <div className='flex min-w-max space-x-4 items-center px-4'>
+          <div onClick={handleDiscover} className='flex space-x-3 items-center cursor-pointer'>
             <Image src={moon} alt='moon' />
             <h1>Discover</h1>
-            </div>
-            <div className="w-[1px] h-[24px] bg-[#9B51E0]"></div>
-            <div className='flex space-x-3 items-center cursor-pointer'onClick={handlerouting}>
+          </div>
+          <div className="w-[1px] h-[24px] bg-[#9B51E0]"></div>
+          <div className='flex space-x-3 items-center cursor-pointer' onClick={handlerouting}>
             <Image src={upcoming} alt='moon' />
             <h1>My Events</h1>
-            </div>
-            <div className="w-[1px] h-[24px] bg-[#9B51E0]"></div>
-            <div className='flex space-x-3 items-center cursor-pointer'>
+          </div>
+          <div className="w-[1px] h-[24px] bg-[#9B51E0]"></div>
+          <div className='flex space-x-3 items-center cursor-pointer'>
             <h1>{props.eventsname}</h1>
-            </div>
+          </div>
         </div>
-                <div className='space-x-6 flex'>
-                <Button className="hidden lg:flex rounded-lg bg-[#4A90E21F] py-2 px-4 lg:h-[50px] items-center lg:w-[138px] text-sm text-[#5801A9] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
-                    <div className="flex space-x-4 items-center font-semibold text-[16px]">
-                    <Image src={edit} alt="ticket" className="mr-2" />
-                    </div>
-                    <div>Edit Event</div>
-                </Button>
-                <Button onClick={handleEventPage} className="hidden justify-center lg:flex rounded-lg bg-[#2D3A4B] py-2 px-4 lg:h-[50px] items-center lg:w-[147px] text-sm text-[#FFFFFF] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
-                    <div>Event Page</div>
-                    <div className="flex space-x-4 items-center font-semibold text-[16px]">
-                    <Image src={goto} alt="ticket" className="" />
-                    </div>
-                </Button>
-                <Image src={top} alt='moon' />
-        </div>
-        
+      </div>
+      <div className='space-x-3 md:space-x-6 flex items-center'>
+        <Button className="flex rounded-lg bg-[#4A90E21F] hover:bg-sky-500 active:bg-sky-700 py-2 px-4 lg:h-[42px] items-center w-[138px] text-sm text-[#5801A9]">
+          <div className="space-x-4 items-center font-semibold text-[16px]">
+            <Image src={edit} alt="ticket" className="mr-2" />
+          </div>
+          <div>Edit Event</div>
+        </Button>
+        <Button onClick={handleEventPage} className="justify-center flex rounded-lg bg-[#2D3A4B] py-2 px-4 lg:h-[42x] items-center w-[147px] text-sm text-[#FFFFFF] data-[hover]:bg-sky-500 data-[active]:bg-sky-700">
+          <div>Event Page</div>
+          <div className="flex space-x-4 items-center font-semibold text-[16px]">
+            <Image src={goto} alt="ticket" className="" />
+          </div>
+        </Button>
+        <Image src={top} alt='moon' className='hidden md:block' />
+      </div>
+
     </div>
   )
 }

--- a/src/components/overview/Sponsorship.tsx
+++ b/src/components/overview/Sponsorship.tsx
@@ -4,10 +4,10 @@ import { approvedsponsors, pendingsponsors } from '@/constants/data'
 
 const Sponsorship = () => {
     return (
-        <div className="h-auto w-full pb-10">
+        <div className="h-auto w-full mx-auto pb-10">
             <h1 className='mb-5 w-[80%] mx-auto font-semibold text-[18px] text-[#333333]'>Sponsorship</h1>
             <div className='h-[360px] rounded-lg w-[80%] mx-auto bg-[#FFFFFF] border-[1px] border-[#DEDEDE] overflow-y-auto '>
-                <table className="border-spacing-y-3 w-[800px]" style={{ tableLayout: 'fixed' }}>
+                <table className="border-spacing-y-3 w-[800px] md:w-[1400px]" style={{ tableLayout: 'fixed' }}>
                     <colgroup>
                         <col span={1} style={{ width: '35%' }} />
                         <col span={1} style={{ width: '10%' }} />
@@ -38,7 +38,7 @@ const Sponsorship = () => {
                     </tbody>
                 </table>
 
-                <table className="border-spacing-y-3 border-b-[2px] w-[800px]" style={{ tableLayout: 'fixed' }}>
+                <table className="border-spacing-y-3 border-b-[2px] w-[800px] md:w-[1400px]" style={{ tableLayout: 'fixed' }}>
                     <colgroup>
                         <col span={1} style={{ width: '35%' }} />
                         <col span={1} style={{ width: '10%' }} />

--- a/src/components/overview/Sponsorship.tsx
+++ b/src/components/overview/Sponsorship.tsx
@@ -1,61 +1,76 @@
 import React from 'react'
 import Sponsorlist from './Sponsorlist'
-import {approvedsponsors,pendingsponsors} from '@/constants/data'
+import { approvedsponsors, pendingsponsors } from '@/constants/data'
 
 const Sponsorship = () => {
-  return (
-    <div className="h-auto w-full pb-10">
-        <h1 className='mb-5 w-[80%] mx-auto font-semibold text-[18px] text-[#333333]'>Sponsorship</h1>
-        <div className='h-[360px] rounded-lg w-[80%] mx-auto bg-[#FFFFFF] border-[1px] border-[#DEDEDE] overflow-y-auto '>
-        <table className="w-full border-spacing-y-3 ">
-                <thead>
-                <tr className="h-[56px] text-[14px] border-b-[2px] font-normal leading-[19.79px]">
-                    <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Sponsors</th>
-                    <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Amount</th>
-                    <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Wallet address</th>
-                    <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Time stamp</th>
-                    <th className="text-center font-light">Contact</th>
-                </tr>
-                </thead>
-                <tbody>
-                    {approvedsponsors.map((data, index) => (
-                    <Sponsorlist 
-                        key={index} 
-                        name={data.name} 
-                        icon={data.icon} 
-                        address={data.address} 
-                        amount={data.amount} 
-                        time={data.time} 
-                    />
-                    ))}
-                </tbody>
-            </table>
+    return (
+        <div className="h-auto w-full pb-10">
+            <h1 className='mb-5 w-[80%] mx-auto font-semibold text-[18px] text-[#333333]'>Sponsorship</h1>
+            <div className='h-[360px] rounded-lg w-[80%] mx-auto bg-[#FFFFFF] border-[1px] border-[#DEDEDE] overflow-y-auto '>
+                <table className="border-spacing-y-3 w-[800px]" style={{ tableLayout: 'fixed' }}>
+                    <colgroup>
+                        <col span={1} style={{ width: '35%' }} />
+                        <col span={1} style={{ width: '10%' }} />
+                        <col span={1} style={{ width: '25%' }} />
+                        <col span={1} style={{ width: '17.5%' }} />
+                        <col span={1} style={{ width: '12.5%' }} />
+                    </colgroup>
+                    <thead>
+                        <tr className="h-[56px] text-[14px] border-b-[2px] font-normal leading-[19.79px]">
+                            <th className="text-center font-light border-r-[2px] border-[#E9EBEC]">Sponsors</th>
+                            <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Amount</th>
+                            <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Wallet address</th>
+                            <th className=" text-center font-light border-r-[2px] border-[#E9EBEC]">Time stamp</th>
+                            <th className="text-center font-light">Contact</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {approvedsponsors.map((data, index) => (
+                            <Sponsorlist
+                                key={index}
+                                name={data.name}
+                                icon={data.icon}
+                                address={data.address}
+                                amount={data.amount}
+                                time={data.time}
+                            />
+                        ))}
+                    </tbody>
+                </table>
 
-            <table className="w-full border-spacing-y-3 border-b-[2px]">
-                <thead>
-                <tr className="h-[56px] text-[14px] border-y-[2px] font-normal leading-[19.79px]">
-                    <th className=" text-center font-light text-[#DC1D16]">Pending</th>
-                    <th className=" text-center font-light text-[#DC1D16]">Amount</th>
-                    <th className=" text-center font-light text-[#DC1D16]">Wallet address</th>
-                    <th className=" text-center font-light text-[#DC1D16]">Time stamp</th>
-                </tr>
-                </thead>
-                <tbody>
-                    {pendingsponsors.map((data, index) => (
-                    <Sponsorlist 
-                        key={index} 
-                        name={data.name} 
-                        icon={data.icon} 
-                        address={data.address} 
-                        amount={data.amount} 
-                        time={data.time} 
-                    />
-                    ))}
-                </tbody>
-            </table>
+                <table className="border-spacing-y-3 border-b-[2px] w-[800px]" style={{ tableLayout: 'fixed' }}>
+                    <colgroup>
+                        <col span={1} style={{ width: '35%' }} />
+                        <col span={1} style={{ width: '10%' }} />
+                        <col span={1} style={{ width: '25%' }} />
+                        <col span={1} style={{ width: '17.5%' }} />
+                        <col span={1} style={{ width: '12.5%' }} />
+                    </colgroup>
+                    <thead>
+                        <tr className="h-[56px] text-[14px] border-y-[2px] font-normal leading-[19.79px]">
+                            <th className=" text-center font-light text-[#DC1D16]">Pending</th>
+                            <th className=" text-center font-light text-[#DC1D16]">Amount</th>
+                            <th className=" text-center font-light text-[#DC1D16]">Wallet address</th>
+                            <th className=" text-center font-light text-[#DC1D16]">Time stamp</th>
+                            <th className=" text-center font-light text-[#DC1D16]">Contact</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {pendingsponsors.map((data, index) => (
+                            <Sponsorlist
+                                key={index}
+                                name={data.name}
+                                icon={data.icon}
+                                address={data.address}
+                                amount={data.amount}
+                                time={data.time}
+                            />
+                        ))}
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </div>
-  )
+    )
 }
 
 export default Sponsorship

--- a/src/components/overview/Tab.tsx
+++ b/src/components/overview/Tab.tsx
@@ -10,7 +10,7 @@ const Tab = () => {
     const [attendanceclickstat, setattendanceclickstat] = useAtom(attendanceclick)
     const [sponsorshipclickstat, setsponsorshipclickstat] = useAtom(sponsorshipclick)
     const router = useRouter();
-  
+
   const handleinsightclick = () => {
     setinsightClickstat(true);
     setguestlistclickstat(false);
@@ -19,7 +19,7 @@ const Tab = () => {
     //@todo replace sample event with event name
     router.push('/Overview/sample-event/insight')
   }
-  
+
   const handlegueslistclick = () =>{
     setinsightClickstat(false);
     setguestlistclickstat(true);
@@ -36,7 +36,7 @@ const Tab = () => {
       //@todo replace sample event with event name
       router.push('/Overview/sample-event/attendance')
   }
-  
+
   const handleSponsorshipclick = () => {
     setinsightClickstat(false);
     setguestlistclickstat(false);
@@ -45,16 +45,55 @@ const Tab = () => {
       //@todo replace sample event with event name
       router.push('/Overview/sample-event/sponsorship')
   }
-  
+
     return (
-    <div className='h-[55px] w-full border-b-[2px] border-[#D0D0D0] items-center flex justify-center'>
-        <div className='w-[50%] clg:w-[55%] lclg:w-[60%] flex space-x-32 h-[40px] mt-5'>
-          <Button onClick={handleinsightclick} className={`${insightClickstat && `border-[#9B51E0] border-b-[4px]`} w-[102px] text-[16px] font-medium text-[#333333]`}>Insights</Button>  
-          <Button onClick={handlegueslistclick} className={`${guestlistclickstat && `border-[#9B51E0] border-b-[4px]`} lg:w-[102px] clg:w-[130px] lclg:w-[200px] text-[16px] font-medium text-[#333333]`} >Guests list</Button>  
-          <Button onClick={handleAttendanceclick} className={`${attendanceclickstat && `border-[#9B51E0] border-b-[4px]`} w-[102px] text-[16px] font-medium text-[#333333]`}>Attendance</Button>  
-          <Button onClick={handleSponsorshipclick} className={`${sponsorshipclickstat && `border-[#9B51E0] border-b-[4px]`} w-[102px] text-[16px] font-medium text-[#333333]`}>Sponsorship</Button>  
+    <div className='h-[55px] w-full border-b-[2px] border-[#D0D0D0] items-end lg:items-center flex justify-start lg:justify-center'>
+        {/* Desktop view */}
+        <div className='hidden md:flex justify-center md:w-[85%] lg:w-[60%] clg:w-[65%] lclg:w-[80%] lg:space-x-20 md:space-x-8 h-[40px] mt-5'>
+          <Button onClick={handleinsightclick} className={`${insightClickstat && `border-[#9B51E0] border-b-[4px]`} text-[16px] font-medium text-[#333333]`}>Insights</Button>
+          <Button onClick={handlegueslistclick} className={`${guestlistclickstat && `border-[#9B51E0] border-b-[4px]`} text-[16px] font-medium text-[#333333]`} >Guests list</Button>
+          <Button onClick={handleAttendanceclick} className={`${attendanceclickstat && `border-[#9B51E0] border-b-[4px]`} text-[16px] font-medium text-[#333333]`}>Attendance</Button>
+          <Button onClick={handleSponsorshipclick} className={`${sponsorshipclickstat && `border-[#9B51E0] border-b-[4px]`} text-[16px] font-medium text-[#333333]`}>Sponsorship</Button>
         </div>
-        
+
+        {/* Mobile dropdown */}
+        <div className='md:hidden w-[60%] pl-[6%] mt-2'>
+          <div className='flex lg:items-center gap-2 border-b-4 border-[#9B51E0]'>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+            <select
+              className='w-full p-2 text-[16px] font-medium text-[#333333] bg-transparent border-none focus:outline-none'
+              onChange={(e) => {
+                switch(e.target.value) {
+                  case 'insights':
+                    handleinsightclick();
+                    break;
+                  case 'guestlist':
+                    handlegueslistclick();
+                    break;
+                  case 'attendance':
+                    handleAttendanceclick();
+                    break;
+                  case 'sponsorship':
+                    handleSponsorshipclick();
+                    break;
+                }
+              }}
+              value={
+                insightClickstat ? 'insights' :
+                guestlistclickstat ? 'guestlist' :
+                attendanceclickstat ? 'attendance' :
+                sponsorshipclickstat ? 'sponsorship' : 'insights'
+              }
+            >
+              <option value="insights">Insights</option>
+              <option value="guestlist">Guests list</option>
+              <option value="attendance">Attendance</option>
+              <option value="sponsorship">Sponsorship</option>
+            </select>
+          </div>
+        </div>
     </div>
   )
 }


### PR DESCRIPTION
## Description
Added responsive design for medium and mobile screens across event management pages while preserving the original desktop implementation. The changes ensure proper display and functionality across all device sizes without modifying the existing desktop view.

## Pages Modified
1. Insights Page (`insight.tsx`)
2. Guestlist Page (`guestlist.tsx`)
3. Attendance Page (`attendance.tsx`)
4. Sponsorship Page (`sponsorship.tsx`)

## Testing
- Verified responsive behavior across following breakpoints:
  - Mobile (<640px)
  - Tablet (640px-768px)
  - Desktop (>768px)
- Tested table scrolling and interaction on mobile devices
- Verified all functionalities work across screen sizes


## Screenshots
- insight page:
<img width="1440" alt="Screenshot 2025-02-04 at 21 47 40" src="https://github.com/user-attachments/assets/c6d6d796-a62c-438a-847d-6cf1fe1e2a18" />
<img width="1440" alt="Screenshot 2025-02-05 at 17 00 36" src="https://github.com/user-attachments/assets/6d1bbac6-37da-4596-b94a-2de4fbfc9897" />
<img width="1440" alt="Screenshot 2025-02-04 at 21 48 05" src="https://github.com/user-attachments/assets/565bb09c-30ba-4088-8b3f-0e4b4b2e650b" />
<img width="1440" alt="Screenshot 2025-02-04 at 21 48 09" src="https://github.com/user-attachments/assets/1dbd4470-d7f5-4061-8efa-391cf2953512" />


- guestlist page:
<img width="1440" alt="Screenshot 2025-02-04 at 21 48 37" src="https://github.com/user-attachments/assets/390e215b-6872-4c11-969b-31d760d5910b" />
<img width="1440" alt="Screenshot 2025-02-05 at 17 00 43" src="https://github.com/user-attachments/assets/3751b554-a9cd-4a5c-ac4d-d9039a982a2a" />
<img width="1440" alt="Screenshot 2025-02-04 at 21 48 55" src="https://github.com/user-attachments/assets/09e10eca-4f47-4ff0-a6af-db8396c2df25" />


- Attendance page:
<img width="1440" alt="Screenshot 2025-02-04 at 21 49 12" src="https://github.com/user-attachments/assets/4175917b-f674-4ec6-a516-9891e95cdee7" />
<img width="1440" alt="Screenshot 2025-02-04 at 21 49 16" src="https://github.com/user-attachments/assets/d78308db-1834-4dbd-ba66-92da2983b3c6" />
<img width="1440" alt="Screenshot 2025-02-05 at 17 00 48" src="https://github.com/user-attachments/assets/898ef548-1481-43a1-b128-5d19fe75765d" />
<img width="1440" alt="Screenshot 2025-02-04 at 21 49 33" src="https://github.com/user-attachments/assets/f0000d22-06ce-471f-bf18-099a52b6b914" />
<img width="1440" alt="Screenshot 2025-02-04 at 21 49 36" src="https://github.com/user-attachments/assets/5b351b35-eadc-43f3-8325-f22c6f034bb4" />


- Sponsorship page:
<img width="1440" alt="Screenshot 2025-02-04 at 21 49 48" src="https://github.com/user-attachments/assets/fed1f6a7-b7d6-4980-8a80-f119fe389b10" />
<img width="1440" alt="Screenshot 2025-02-05 at 17 00 54" src="https://github.com/user-attachments/assets/5dbc753c-57cf-4396-aba2-1d1f224ca2a0" />


## Notes
- All responsive changes are additive through Tailwind classes
- Original functionality preserved across all screen sizes

### Links:
http://localhost:3000/Overview/sample-event/insight
http://localhost:3000/Overview/sample-event/guestlist
http://localhost:3000/Overview/sample-event/attendance
http://localhost:3000/Overview/sample-event/sponsorship